### PR TITLE
HA Core 2025.1 deprecated constant updates

### DIFF
--- a/custom_components/panasonic_cc/__init__.py
+++ b/custom_components/panasonic_cc/__init__.py
@@ -1,25 +1,20 @@
 """Platform for the Panasonic Comfort Cloud."""
-from datetime import timedelta
 import logging
-from typing import Any, Dict
+from typing import Dict
 
 import asyncio
-from async_timeout import timeout
 
 import voluptuous as vol
 
 from homeassistant.core import HomeAssistant
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_USERNAME, CONF_PASSWORD)
-from homeassistant.exceptions import ConfigEntryNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import HomeAssistantType
 
-from homeassistant.helpers import discovery
 
 from .const import (
-    TIMEOUT, 
     CONF_FORCE_OUTSIDE_SENSOR, 
     DEFAULT_FORCE_OUTSIDE_SENSOR, 
     CONF_ENABLE_DAILY_ENERGY_SENSOR, 
@@ -38,8 +33,8 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Required(CONF_USERNAME): cv.string,
                 vol.Required(CONF_PASSWORD): cv.string,
-                vol.Optional(CONF_FORCE_OUTSIDE_SENSOR, default=DEFAULT_FORCE_OUTSIDE_SENSOR): cv.boolean,
-                vol.Optional(CONF_ENABLE_DAILY_ENERGY_SENSOR, default=DEFAULT_ENABLE_DAILY_ENERGY_SENSOR): cv.boolean,
+                vol.Optional(CONF_FORCE_OUTSIDE_SENSOR, default=DEFAULT_FORCE_OUTSIDE_SENSOR): cv.boolean,  # noqa: E501
+                vol.Optional(CONF_ENABLE_DAILY_ENERGY_SENSOR, default=DEFAULT_ENABLE_DAILY_ENERGY_SENSOR): cv.boolean, # noqa: E501
             }
         )
     },

--- a/custom_components/panasonic_cc/climate.py
+++ b/custom_components/panasonic_cc/climate.py
@@ -2,16 +2,14 @@
 import logging
 
 import voluptuous as vol
-from typing import Any, Dict, Optional, List
+from typing import Optional, List
 
-from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateEntity, HVACAction, HVACMode
-from homeassistant.components.climate.const import HVAC_MODE_OFF, SUPPORT_PRESET_MODE
-from homeassistant.helpers import config_validation as cv, entity_platform, service
+from homeassistant.components.climate import ClimateEntity, HVACAction, HVACMode
+from homeassistant.helpers import config_validation as cv, entity_platform
 
-from homeassistant.const import (
-    TEMP_CELSIUS, ATTR_TEMPERATURE)
+from homeassistant.const import UnitOfTemperature
 
-from . import DOMAIN as PANASONIC_DOMAIN, PANASONIC_DEVICES
+from . import PANASONIC_DEVICES
 
 from .const import (
     SUPPORT_FLAGS, 
@@ -96,7 +94,7 @@ class PanasonicClimateDevice(ClimateEntity):
     @property
     def temperature_unit(self):
         """Return the unit of measurement."""
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
 
     @property
     def target_temperature(self):
@@ -110,7 +108,7 @@ class PanasonicClimateDevice(ClimateEntity):
     def hvac_mode(self):
         """Return the current operation."""
         if not self._api.is_on:
-            return HVAC_MODE_OFF
+            return HVACMode.OFF
         hvac_mode = self._api.hvac_mode
         for key, value in OPERATION_LIST.items():
             if value == hvac_mode:
@@ -123,7 +121,7 @@ class PanasonicClimateDevice(ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode):
         """Set HVAC mode."""
-        if hvac_mode == HVAC_MODE_OFF:
+        if hvac_mode == HVACMode.OFF:
             await self._api.turn_off()
         else:
             await self._api.set_hvac_mode(hvac_mode)
@@ -184,7 +182,8 @@ class PanasonicClimateDevice(ClimateEntity):
     @property
     def swing_modes(self):
         """Return the list of available swing modes."""
-        supported = lambda x: x != self._api.constants.AirSwingUD.All or (self._api.features is not None and self._api.features['upDownAllSwing'])
+        def supported(x):
+            return x != self._api.constants.AirSwingUD.All or self._api.features is not None and self._api.features['upDownAllSwing']  # noqa: E501
         return [f.name for f in filter(supported, self._api.constants.AirSwingUD) ]
 
     @property

--- a/custom_components/panasonic_cc/const.py
+++ b/custom_components/panasonic_cc/const.py
@@ -1,10 +1,7 @@
 """Constants for Panasonic Cloud."""
 from homeassistant.const import CONF_ICON, CONF_NAME, CONF_TYPE
 from homeassistant.components.climate.const import (
-    HVAC_MODE_COOL, HVAC_MODE_HEAT, HVAC_MODE_HEAT_COOL,
-    HVAC_MODE_DRY, HVAC_MODE_FAN_ONLY, HVAC_MODE_OFF,
-    SUPPORT_TARGET_TEMPERATURE, SUPPORT_FAN_MODE, 
-    SUPPORT_SWING_MODE, SUPPORT_PRESET_MODE,
+    HVACMode, ClimateEntityFeature,
     PRESET_ECO, PRESET_NONE, PRESET_BOOST)
 
 ATTR_TARGET_TEMPERATURE = "target_temperature"
@@ -58,10 +55,10 @@ ENERGY_SENSOR_TYPES = {
 }
 
 SUPPORT_FLAGS = (
-    SUPPORT_TARGET_TEMPERATURE |
-    SUPPORT_FAN_MODE |
-    SUPPORT_PRESET_MODE |
-    SUPPORT_SWING_MODE )
+    ClimateEntityFeature.TARGET_TEMPERATURE |
+    ClimateEntityFeature.FAN_MODE |
+    ClimateEntityFeature.PRESET_MODE |
+    ClimateEntityFeature.SWING_MODE )
 
 PRESET_LIST = {
     PRESET_NONE: 'Auto',
@@ -70,10 +67,10 @@ PRESET_LIST = {
 }
 
 OPERATION_LIST = {
-    HVAC_MODE_OFF: 'Off',
-    HVAC_MODE_HEAT: 'Heat',
-    HVAC_MODE_COOL: 'Cool',
-    HVAC_MODE_HEAT_COOL: 'Auto',
-    HVAC_MODE_DRY: 'Dry',
-    HVAC_MODE_FAN_ONLY: 'Fan'
+    HVACMode.OFF: 'Off',
+    HVACMode.HEAT: 'Heat',
+    HVACMode.COOL: 'Cool',
+    HVACMode.HEAT_COOL: 'Auto',
+    HVACMode.DRY: 'Dry',
+    HVACMode.FAN_ONLY: 'Fan'
     }

--- a/custom_components/panasonic_cc/panasonic.py
+++ b/custom_components/panasonic_cc/panasonic.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 import logging
 from datetime import datetime
 
-from typing import Any, Dict, Optional, List
+from typing import Optional
 from homeassistant.util import Throttle
 from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.helpers.typing import HomeAssistantType
@@ -19,14 +19,14 @@ def api_call_login(func):
     def wrapper_call(*args, **kwargs):
         try:
             func(*args, **kwargs)
-        except:
+        except:  # noqa: E722
             args[0]._api.login()
             func(*args, **kwargs)
     return wrapper_call
 
 class PanasonicApiDevice:
 
-    def __init__(self, hass: HomeAssistantType, api, device, force_outside_sensor, enable_energy_sensor):
+    def __init__(self, hass: HomeAssistantType, api, device, force_outside_sensor, enable_energy_sensor): # noqa: E501
         from .pcomfortcloud import constants
         self.hass = hass
         self._api = api
@@ -74,12 +74,12 @@ class PanasonicApiDevice:
         try:
             data= await self.hass.async_add_executor_job(self._api.get_device,self.id)
         except:
-            _LOGGER.debug("Error trying to get device {id} state, probably expired token, trying to update it...".format(**self.device))
+            _LOGGER.debug("Error trying to get device {id} state, probably expired token, trying to update it...".format(**self.device)) # noqa: E501
             try:
                 await self.hass.async_add_executor_job(self._api.login)
                 data= await self.hass.async_add_executor_job(self._api.get_device,self.id)
             except:
-                _LOGGER.debug("Failed to renew token for device {id}, giving up for now".format(**self.device))
+                _LOGGER.debug("Failed to renew token for device {id}, giving up for now".format(**self.device))  # noqa: E501
                 return
 
         if data is None:
@@ -96,7 +96,7 @@ class PanasonicApiDevice:
                 self._inside_temperature = plst['temperatureInside']
             if plst['temperatureOutside'] != 126:
                 self._outside_temperature = plst['temperatureOutside']
-                if self._inside_temperature is None and self._outside_temperature is not None:
+                if self._inside_temperature is None and self._outside_temperature is not None: # noqa: E501
                     self._inside_temperature = self._outside_temperature
             if plst['temperature'] != 126:
                 self._target_temperature = plst['temperature']
@@ -117,19 +117,19 @@ class PanasonicApiDevice:
     async def do_update_energy(self):
         #_LOGGER.debug("Requesting energy for device {id}".format(**self.device))
         try:
-            data= await self.hass.async_add_executor_job(self._api.history,self.id,"Day",datetime.now().strftime("%Y%m%d"))
+            data= await self.hass.async_add_executor_job(self._api.history,self.id,"Day",datetime.now().strftime("%Y%m%d")) # noqa: E501
             
         except:
-            _LOGGER.debug("Error trying to get device {id} state, probably expired token, trying to update it...".format(**self.device))
+            _LOGGER.debug("Error trying to get device {id} state, probably expired token, trying to update it...".format(**self.device)) # noqa: E501
             try:
                 await self.hass.async_add_executor_job(self._api.login)
-                data= await self.hass.async_add_executor_job(self._api.get_device,self.id)
+                data= await self.hass.async_add_executor_job(self._api.get_device,self.id) # noqa: E501
             except:
-                _LOGGER.debug("Failed to renew token for device {id}, giving up for now".format(**self.device))
+                _LOGGER.debug("Failed to renew token for device {id}, giving up for now".format(**self.device)) # noqa: E501
                 return
 
         if data is None:
-            _LOGGER.debug("Received no energy data for device {id}".format(**self.device))
+            _LOGGER.debug("Received no energy data for device {id}".format(**self.device)) # noqa: E501
             return
         t1 = datetime.now()
         if 'energyConsumption' in data['parameters']:
@@ -137,7 +137,7 @@ class PanasonicApiDevice:
             if c_energy:
                 if self.last_energy_reading_time is not None:
                     if c_energy != self.last_energy_reading:                
-                        d = (t1 - self.last_energy_reading_time).total_seconds() / 60 / 60
+                        d = (t1 - self.last_energy_reading_time).total_seconds() / 60 / 60  # noqa: E501
                         p = round((c_energy - self.last_energy_reading)*1000 / d)
                         self.last_energy_reading = c_energy
                         self.last_energy_reading_time = t1
@@ -178,7 +178,7 @@ class PanasonicApiDevice:
 
     @property
     def support_inside_temperature(self):
-        return self._inside_temperature != None
+        return self._inside_temperature is not None
 
     @property
     def outside_temperature(self):
@@ -188,7 +188,7 @@ class PanasonicApiDevice:
     def support_outside_temperature(self):
         if self.force_outside_sensor:
             return True
-        return self._outside_temperature != None
+        return self._outside_temperature is not None
 
     @property
     def target_temperature(self):

--- a/custom_components/panasonic_cc/sensor.py
+++ b/custom_components/panasonic_cc/sensor.py
@@ -1,18 +1,15 @@
 """Support for Panasonic sensors."""
 import logging
 
-from homeassistant.const import CONF_ICON, CONF_NAME, TEMP_CELSIUS, CONF_TYPE
+from homeassistant.const import CONF_ICON, CONF_NAME, CONF_TYPE, UnitOfTemperature
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import (
-    DEVICE_CLASS_ENERGY,
-    DEVICE_CLASS_POWER,
-    PLATFORM_SCHEMA,
-    STATE_CLASS_TOTAL_INCREASING,
-    STATE_CLASS_MEASUREMENT,
     SensorEntity,
+    SensorStateClass,
+    SensorDeviceClass
 )
 
-from . import DOMAIN as PANASONIC_DOMAIN, PANASONIC_DEVICES
+from . import PANASONIC_DEVICES
 from .const import (
     ATTR_INSIDE_TEMPERATURE, 
     ATTR_OUTSIDE_TEMPERATURE, 
@@ -91,7 +88,7 @@ class PanasonicClimateSensor(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
 
     async def async_update(self):
         """Retrieve latest state."""
@@ -112,11 +109,11 @@ class PanasonicEnergySensor(SensorEntity):
         self._name = f"{api.name} {self._sensor[CONF_NAME]}"
         self._device_attribute = monitored_state
         if self._device_attribute == ATTR_DAILY_ENERGY:
-            self._attr_state_class = STATE_CLASS_TOTAL_INCREASING
-            self._attr_device_class = DEVICE_CLASS_ENERGY
+            self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+            self._attr_device_class = SensorDeviceClass.ENERGY
         else:
-            self._attr_state_class = STATE_CLASS_MEASUREMENT
-            self._attr_device_class = DEVICE_CLASS_POWER
+            self._attr_state_class = SensorStateClass.MEASUREMENT
+            self._attr_device_class = SensorDeviceClass.POWER
 
     @property
     def unique_id(self):


### PR DESCRIPTION
Logger: homeassistant.components.climate.const
Source: helpers/deprecation.py:205
Integration: Climate (documentation, issues)
First occurred: 22:01:15 (12 occurrences)
Last logged: 22:01:30

HVAC_MODE_OFF was used from panasonic_cc, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACMode.OFF instead, please create a bug report at https://github.com/sockless-coding/panasonic_cc/issues
SUPPORT_TARGET_TEMPERATURE was used from panasonic_cc, this is a deprecated constant which will be removed in HA Core 2025.1. Use ClimateEntityFeature.TARGET_TEMPERATURE instead, please create a bug report at https://github.com/sockless-coding/panasonic_cc/issues
SUPPORT_FAN_MODE was used from panasonic_cc, this is a deprecated constant which will be removed in HA Core 2025.1. Use ClimateEntityFeature.FAN_MODE instead, please create a bug report at https://github.com/sockless-coding/panasonic_cc/issues
SUPPORT_SWING_MODE was used from panasonic_cc, this is a deprecated constant which will be removed in HA Core 2025.1. Use ClimateEntityFeature.SWING_MODE instead, please create a bug report at https://github.com/sockless-coding/panasonic_cc/issues
SUPPORT_PRESET_MODE was used from panasonic_cc, this is a deprecated constant which will be removed in HA Core 2025.1. Use ClimateEntityFeature.PRESET_MODE instead, please create a bug report at https://github.com/sockless-coding/panasonic_cc/issues