### PR TITLE
Resolve regex pattern matching bug

### DIFF
--- a/custom_components/panasonic_cc/pcomfortcloud/urls.py
+++ b/custom_components/panasonic_cc/pcomfortcloud/urls.py
@@ -20,13 +20,13 @@ def get_groups():
 def status(guid):
     return '{base_url}/deviceStatus/{guid}'.format(
         base_url=BASE_URL,
-        guid=re.sub('(?i)\%2f', 'f', quote_plus(guid))
+        guid=re.sub(r'(?i)\%2f', 'f', quote_plus(guid))
     )
 
 def statusCache(guid):
     return '{base_url}/deviceStatus/now/{guid}'.format(
         base_url=BASE_URL,
-        guid=re.sub('(?i)\%2f', 'f', quote_plus(guid))
+        guid=re.sub(r'(?i)\%2f', 'f', quote_plus(guid))
     )
 
 def control():


### PR DESCRIPTION
Resolve
```
SyntaxWarning: invalid escape sequence '\%' guid=re.sub('(?i)\%2f', 'f', quote_plus(guid))
```