### PR TITLE
Working out executor issues

### DIFF
--- a/custom_components/panasonic_cc/__init__.py
+++ b/custom_components/panasonic_cc/__init__.py
@@ -67,7 +67,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         force_outside_sensor = conf[CONF_FORCE_OUTSIDE_SENSOR]
     enable_daily_energy_sensor = entry.options.get(CONF_ENABLE_DAILY_ENERGY_SENSOR, DEFAULT_ENABLE_DAILY_ENERGY_SENSOR)
 
-    api = pcomfortcloud.Session(username, password)
+    api = await hass.async_add_executor_job(pcomfortcloud.Session(username, password))
+
     devices = await hass.async_add_executor_job(api.get_devices)
     for device in devices:
         try:


### PR DESCRIPTION
```
Logger: homeassistant.config_entries
Source: config_entries.py:594
First occurred: 22:20:41 (2 occurrences)
Last logged: 22:20:56

Error setting up entry for panasonic_cc
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 594, in async_setup
    result = await component.async_setup_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/panasonic_cc/__init__.py", line 70, in async_setup_entry
    api = pcomfortcloud.Session(username, password)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/panasonic_cc/pcomfortcloud/session.py", line 256, in __init__
    self._token = get_and_save_new_token(self._username, self._password, self._tokenFileName)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/panasonic_cc/pcomfortcloud/session.py", line 229, in get_and_save_new_token
    token = get_new_token(username, password)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/panasonic_cc/pcomfortcloud/session.py", line 106, in get_new_token
    response = requests_session.get(
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/requests/sessions.py", line 602, in get
    return self.request("GET", url, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/requests/adapters.py", line 667, in send
    resp = conn.urlopen(
           ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/urllib3/connectionpool.py", line 715, in urlopen
    httplib_response = self._make_request(
                       ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/urllib3/connectionpool.py", line 416, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/usr/local/lib/python3.12/site-packages/urllib3/connection.py", line 244, in request
    super(HTTPConnection, self).request(method, url, body=body, headers=headers)
  File "/usr/local/lib/python3.12/http/client.py", line 1331, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/local/lib/python3.12/http/client.py", line 1342, in _send_request
    self.putrequest(method, url, **skips)
  File "/usr/local/lib/python3.12/site-packages/urllib3/connection.py", line 219, in putrequest
    return _HTTPConnection.putrequest(self, method, url, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/util/loop.py", line 123, in protected_loop_func
    raise_for_blocking_call(
  File "/usr/src/homeassistant/homeassistant/util/loop.py", line 102, in raise_for_blocking_call
    raise RuntimeError(
RuntimeError: Blocking calls must be done in the executor or a separate thread; Use `await hass.async_add_executor_job()`; at custom_components/panasonic_cc/pcomfortcloud/session.py, line 106: response = requests_session.get( (offender: /usr/local/lib/python3.12/site-packages/urllib3/connection.py, line 219: return _HTTPConnection.putrequest(self, method, url, *args, **kwargs))
```