### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/panasonic_cc/__init__.py
+++ b/custom_components/panasonic_cc/__init__.py
@@ -68,7 +68,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     enable_daily_energy_sensor = entry.options.get(CONF_ENABLE_DAILY_ENERGY_SENSOR, DEFAULT_ENABLE_DAILY_ENERGY_SENSOR)
 
     session = pcomfortcloud.Session(username, password)
-    api = await hass.async_add_executor_job(session.load_token())
+    api = await hass.async_add_executor_job(session.load_token)
     devices = await hass.async_add_executor_job(api.get_devices)
     for device in devices:
         try:


### PR DESCRIPTION
This should fix the async execution error, however there's more work that needs to be done on config_entries.py:

Error setting up entry for panasonic_cc
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 594, in async_setup
    result = await component.async_setup_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/panasonic_cc/__init__.py", line 72, in async_setup_entry
    devices = await hass.async_add_executor_job(api.get_devices)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/panasonic_cc/pcomfortcloud/session.py", line 362, in get_devices
    for group in self._groups['groupList']:
                 ~~~~~~~~~~~~^^^^^^^^^^^^^
TypeError: 'NoneType' object is not subscriptable