### PR TITLE
Apply constant changes to the climate sensor

### DIFF
--- a/custom_components/panasonic_cc/climate.py
+++ b/custom_components/panasonic_cc/climate.py
@@ -130,7 +130,8 @@ class PanasonicClimateDevice(ClimateEntity):
     @property
     def hvac_action(self):
         if not self._api.is_on:
-            HVACAction.OFF
+            return HVACAction.OFF
+
         hvac_mode = self.hvac_mode
         if (
                 (hvac_mode == HVACMode.HEAT or hvac_mode == HVACMode.HEAT_COOL)
@@ -186,7 +187,7 @@ class PanasonicClimateDevice(ClimateEntity):
         """Return the list of available swing modes."""
 
         def supported(x):
-            return x != self._api.constants.AirSwingUD.All or self._api.features is not None and self._api.features[
+            return x != self._api.constants.AirSwingUD.Swing or self._api.features is not None and self._api.features[
                 'upDownAllSwing']  # noqa: E501
 
         return [f.name for f in filter(supported, self._api.constants.AirSwingUD)]


### PR DESCRIPTION
```
Logger: homeassistant.components.climate
Source: helpers/entity_platform.py:600
integration: Climate (documentation, issues)
First occurred: 15:16:47 (1 occurrences)
Last logged: 15:16:47

Error adding entity None for domain climate with platform panasonic_cc
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 600, in _async_add_entities
    await coro
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 818, in _async_add_entity
    capabilities=entity.capability_attributes,
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/climate/__init__.py", line 324, in __getattribute__
    return super().__getattribute__(__name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/climate/__init__.py", line 509, in capability_attributes
    data[ATTR_SWING_MODES] = self.swing_modes
                             ^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/climate/__init__.py", line 324, in __getattribute__
    return super().__getattribute__(__name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/panasonic_cc/climate.py", line 192, in swing_modes
    return [f.name for f in filter(supported, self._api.constants.AirSwingUD)]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/panasonic_cc/climate.py", line 189, in supported
    return x != self._api.constants.AirSwingUD.All or self._api.features is not None and self._api.features[
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: type object 'AirSwingUD' has no attribute 'All'
```